### PR TITLE
Improve redis_lb logrotate user & group permission

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -93,7 +93,10 @@ template '/etc/opscode/logrotate.d/redis_lb' do
   owner 'root'
   group 'root'
   mode '0644'
-  variables(redis.to_hash)
+  variables(redis.to_hash.merge(
+    'owner' => OmnibusHelper.new(node).ownership['owner'],
+    'group' => OmnibusHelper.new(node).ownership['group']
+  ))
 end
 
 #


### PR DESCRIPTION
We installed the latest cinc-server, version 14.16.19.
In our case the server config files are in /etc/cinc-project and we noticed
that redis_lb logrotate script is trying to use the non-existant cinc-project
user and group for the rotated file ownership:

cat /etc/cinc-project/logrotate.d/redis_lb
/var/log/cinc-project/redis_lb/*.log {
  rotate 10
  size 1000000
  create 644 cinc-project cinc-project
}

It looks like the redis_lb file is built from the generic template:
omnibus/files/server-ctl-cookbooks/infra-server/templates/default/logrotate.erb

which has an entry like:
 create 644 <%= @owner || ChefUtils::Dist::Org::LEGACY_CONF_DIR %> \
<%= @group || ChefUtils::Dist::Org::LEGACY_CONF_DIR %>

We propose a small change in the redis_lb.rb recipe:
omnibus/files/server-ctl-cookbooks/infra-server/recipes/redis_lb.rb
(similar with the nginx.rb recipe), swapping on line 96:

- variables(redis.to_hash)

with:
+  variables(redis_data.to_hash.merge(
+    'owner' => OmnibusHelper.new(node).ownership['owner'],
+    'group' => OmnibusHelper.new(node).ownership['group']
+    ))

Sorry, and thank you! :pray:

Tensibai at 5:13 PM: Sounds reasonable, would you be up to make a PR on our side ?
Steve Baroti: :panda_dance:

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
