### PR TITLE
improve logrotate redis_lb owner & group

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -93,7 +93,10 @@ template '/etc/opscode/logrotate.d/redis_lb' do
   owner 'root'
   group 'root'
   mode '0644'
-  variables(redis.to_hash)
+  variables(redis.to_hash.merge(
+    'owner' => OmnibusHelper.new(node).ownership['owner'],
+    'group' => OmnibusHelper.new(node).ownership['group']
+  ))
 end
 
 #


### PR DESCRIPTION
### Description

Using cinc-server, version 14.16.19, with custom configuration files
located in "/etc/cinc-project" directory, we noticed that redis_lb
logrotate script uses non-existant "cinc-project" user and group for
rotated file ownership:

  cat /etc/cinc-project/logrotate.d/redis_lb
  /var/log/cinc-project/redis_lb/*.log {
    rotate 10
    size 1000000
    create 644 cinc-project cinc-project
  }

Warning emails were frequently received:
  /etc/cron.hourly/opc_logrotate:
  error: redis_lb:4 unknown user 'cinc-project'
  error: found error in /var/log/cinc-project/redis_lb/*.log , skipping
  error: found error in file redis_lb, skipping

The redis_lb file is built using generic logrotate.erb template from:
omnibus/files/server-ctl-cookbooks/infra-server/templates/default/
with a user and group owner entry from LEGACY_CONF_DIR:

  create 644 <%= @Owner || ChefUtils::Dist::Org::LEGACY_CONF_DIR %>
    <%= @group || ChefUtils::Dist::Org::LEGACY_CONF_DIR %>

[Please describe what this change achieves]

We propose a small change in redis_lb.rb recipe:
omnibus/files/server-ctl-cookbooks/infra-server/recipes/redis_lb.rb
(similar with the nginx.rb recipe which works well for custom
/etc/cinc-project server file location):

swap:
  variables(redis.to_hash)

with:
  variables(redis.to_hash.merge(
      'owner' => OmnibusHelper.new(node).ownership['owner'],
      'group' => OmnibusHelper.new(node).ownership['group']
  ))


### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
